### PR TITLE
Add feature to hide legend buttons while keeping legend

### DIFF
--- a/src/components/Legend.vue
+++ b/src/components/Legend.vue
@@ -23,6 +23,7 @@
     <div v-for="ind in this.indicators" class="t-vue-ind">
         <span class="t-vue-iname">{{ind.name}}</span>
         <button-group
+            v-if="ind.showLegendButtons"
             :buttons="common.buttons"
             :config="common.config"
             :ov_id="ind.id"
@@ -102,7 +103,8 @@ export default {
                     id: id,
                     values: values ? f(id, values) : this.n_a(1),
                     unk: !(id in (this.$props.meta_props || {})),
-                    loading: x.loading
+                    loading: x.loading,
+                    showLegendButtons: 'legendButtons' in x.settings ? x.settings.legendButtons : true
                 }
             })
         },


### PR DESCRIPTION
## Add feature to show the legend text of an overlay while disabling the legend buttons
- Change the following settings in the overlays `settings` object
- Set `legend: true` and set `legendButtons: false` this will hide the legend buttons while displaying the labels.
- You can also do the same on the `data.json` in the specific overlays `settings` block